### PR TITLE
3.0 - Fixes permission issue executing build.sh

### DIFF
--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -7,7 +7,8 @@ ENV FBURL=http://downloads.sourceforge.net/project/firebird/firebird/3.0-Release
 
 ADD build.sh ./build.sh
 
-RUN ./build.sh && \
+RUN chmod +x ./build.sh && \
+    ./build.sh && \
     rm -f ./build.sh
 
 VOLUME ["/databases", "/var/firebird/run", "/var/firebird/etc", "/var/firebird/log", "/var/firebird/system", "/tmp/firebird"]


### PR DESCRIPTION
build.sh is throwing a permission execution due not being a
executable script.

This commits adds a previous updates of the file permission to
be able to execute it
