### PR TITLE
Jaybird 3 does not support the Firebird 3 wire encryption nor zlib co…

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -55,3 +55,4 @@ mv /var/firebird/system/security3.fdb ${PREFIX}/security3.fdb
 # something standard. See github issue https://github.com/jacobalberty/firebird-docker/issues/12
 sed -i 's/^#DatabaseAccess/DatabaseAccess/g' /var/firebird/etc/firebird.conf
 sed -i "s~^\(DatabaseAccess\s*=\s*\).*$~\1Restrict ${DBPATH}~" /var/firebird/etc/firebird.conf
+sed -i 's/^#WireCrypt = Enabled/WireCrypt = Enabled #/g' /var/firebird/etc/firebird.conf


### PR DESCRIPTION
Jaybird 3 does not support the Firebird 3 wire encryption nor zlib compression.

https://www.firebirdsql.org/file/documentation/drivers_documentation/java/3.0.0/release_notes.html#notes-on-firebird-3-support