### PR TITLE
Solve problem with SYSDBA init without legacy auth

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -93,12 +93,21 @@ if [ ! -f "${VOLUME}/system/security3.fdb" ]; then
        echo "setting 'SYSDBA' password to '${ISC_PASSWORD}'"
     fi
 
+    # initialize SYSDBA user for Srp authentication
     ${PREFIX}/bin/isql -user sysdba "${VOLUME}/system/security3.fdb" <<EOL
-create or alter user SYSDBA password '${ISC_PASSWORD}' using plugin Legacy_UserManager;
 create or alter user SYSDBA password '${ISC_PASSWORD}' using plugin Srp;
 commit;
 quit;
 EOL
+
+    if [[ ${EnableLegacyClientAuth} == 'true' ]]; then
+        # also initialize/reset SYSDBA user for legacy authentication
+        ${PREFIX}/bin/isql -user sysdba "${VOLUME}/system/security3.fdb" <<EOL
+create or alter user SYSDBA password '${ISC_PASSWORD}' using plugin Legacy_UserManager;
+commit;
+quit;
+EOL
+    fi
 # create or alter user SYSDBA password '${ISC_PASSWORD}';
 
     cat > "${VOLUME}/etc/SYSDBA.password" <<EOL


### PR DESCRIPTION
Only initialize legacy_auth user if legacy authentication is enabled. This should fix the issue mentioned in [this comment](https://github.com/jacobalberty/firebird-docker/issues/24#issuecomment-489415430).