### PR TITLE
Replace usage of security database path with alias

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -94,7 +94,7 @@ if [ ! -f "${VOLUME}/system/security3.fdb" ]; then
     fi
 
     # initialize SYSDBA user for Srp authentication
-    ${PREFIX}/bin/isql -user sysdba "${VOLUME}/system/security3.fdb" <<EOL
+    ${PREFIX}/bin/isql -user sysdba security.db <<EOL
 create or alter user SYSDBA password '${ISC_PASSWORD}' using plugin Srp;
 commit;
 quit;
@@ -102,7 +102,7 @@ EOL
 
     if [[ ${EnableLegacyClientAuth} == 'true' ]]; then
         # also initialize/reset SYSDBA user for legacy authentication
-        ${PREFIX}/bin/isql -user sysdba "${VOLUME}/system/security3.fdb" <<EOL
+        ${PREFIX}/bin/isql -user sysdba security.db <<EOL
 create or alter user SYSDBA password '${ISC_PASSWORD}' using plugin Legacy_UserManager;
 commit;
 quit;


### PR DESCRIPTION
This should fix #51. I was able to verify this solution through WSL Ubuntu, and it works.

The only edge case is situations where the `databases.conf` has been replaced with a file that does not contain an entry for `security.db`, but as the documentation says _"Do not remove it until you understand well what are you doing!"_, I think that is a reasonable thing to expect to be present.