### PR TITLE
Switch to debian:buster-slim as base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:buster-slim
 
 LABEL maintainer="jacob.alberty@foundigital.com"
 

--- a/build.sh
+++ b/build.sh
@@ -4,16 +4,18 @@ CPUC=$(awk '/^processor/{n+=1}END{print n}' /proc/cpuinfo)
 
 apt-get update
 apt-get install -qy --no-install-recommends \
-    libicu52 \
-    libtommath0
+    libicu63 \
+    libncurses6 \
+    libtommath1
 apt-get install -qy --no-install-recommends \
     bzip2 \
     ca-certificates \
     curl \
+    file \
     g++ \
     gcc \
     libicu-dev \
-    libncurses5-dev \
+    libncurses-dev \
     libtommath-dev \
     make \
     zlib1g-dev
@@ -39,10 +41,11 @@ apt-get purge -qy --auto-remove \
     bzip2 \
     ca-certificates \
     curl \
+    file \
     g++ \
     gcc \
     libicu-dev \
-    libncurses5-dev \
+    libncurses-dev \
     libtommath-dev \
     make \
     zlib1g-dev


### PR DESCRIPTION
Debian jessie is out of regular security support.