### PR TITLE
Don't trigger workflow on forks

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   main:
+    if: github.repository == 'jacobalberty/firebird-docker'
     runs-on: ubuntu-latest
     steps:
       -


### PR DESCRIPTION
On forks, the workflow attempts to push to docker hub and fails because of the missing credentials. This change only triggers the workflow on jacobalberty/firebird-docker.